### PR TITLE
fix(scene) - change scene compile error

### DIFF
--- a/include/scene/scene_manager.h
+++ b/include/scene/scene_manager.h
@@ -16,9 +16,9 @@
 namespace Scene::Config
 {
     // starting scene
-    using StartingScene = Demo;
+    using StartingScene = DemoRender;
 
-    using SceneTuple = std::tuple<Demo, DemoSceneChange>;
+    using SceneTuple = std::tuple<DemoRender>;
     using SceneVariant = Utils::make_scene_variant_t<SceneTuple>;
     using TaskManagerVariant = Utils::make_task_manager_variant_t<SceneTuple>;
 
@@ -65,7 +65,10 @@ namespace Scene
         template<typename T>
         static void queue_change_scene()
         {
-            instance()._next_scene_template = T::instance();
+            if (Utils::is_type_in_tuple_v<T, Scene::Config::SceneTuple>)
+            {
+                instance()._next_scene_template = T::instance();
+            }
         }
 
         static void update();
@@ -78,6 +81,13 @@ namespace Scene
     template<typename T>
     void queue_change_scene()
     {
-        SceneManager::queue_change_scene<T>();
+        if constexpr (Utils::is_type_in_tuple_v<T, Config::SceneTuple>)
+        {
+            SceneManager::queue_change_scene<T>();
+        }
+        else
+        {
+            LOG_ERROR("Error: Scene %s is not in the scene tuple, cannot change to this scene", T::name);
+        }
     }
 } // namespace Scene

--- a/include/utils/scene_utils.h
+++ b/include/utils/scene_utils.h
@@ -92,4 +92,14 @@ namespace Utils
         return rm_converted;
     }
 
+    template<typename T, typename Tuple>
+    constexpr bool is_type_in_tuple_v = []()
+    {
+        constexpr auto helper = []<std::size_t... I>(std::index_sequence<I...>)
+        {
+            return ((std::is_same_v<T, std::tuple_element_t<I, Tuple>> ? true : false) || ...);
+        };
+        return (helper(std::make_index_sequence<std::tuple_size_v<Tuple>>{}));
+    }();
+
 } // namespace Utils


### PR DESCRIPTION
Fixes the compile error when the scene to change to is not in the SceneTuple, and switching to a runtime error. This should be better in the development setting where we discard a lot of fragment systems that may call change scene.