### PR TITLE
fix(get-assets-id) - null check

### DIFF
--- a/src/assets_manager/assets_manager.c
+++ b/src/assets_manager/assets_manager.c
@@ -168,6 +168,9 @@ assets_id get_assets_id(const char *name)
     size_t i = 0;
     for (; i < record_index; ++i)
     {
+        if (id_map[i].id == (uint32_t) -1)
+            continue;
+
         if (strcmp(name, id_map[i].name) == 0)
             return id_map[i].id;
     }


### PR DESCRIPTION
fixes an issue whereby get_assets_id() will throw an error if there exists an invalid id in the id_map while it iterates to find the correct name.